### PR TITLE
Fix a bug in `y_domain`

### DIFF
--- a/.github/TagBot.yml
+++ b/.github/TagBot.yml
@@ -1,0 +1,15 @@
+name: TagBot
+on:
+  issue_comment:
+    types:
+      - created
+  workflow_dispatch:
+jobs:
+  TagBot:
+    if: github.event_name == 'workflow_dispatch' || github.actor == 'JuliaTagBot'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: JuliaRegistries/TagBot@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          lookback: 3

--- a/Project.toml
+++ b/Project.toml
@@ -1,10 +1,11 @@
 name = "OrthogonalSphericalShellGrids"
 uuid = "c2be9673-fb75-4747-82dc-aa2bb9f4aed0"
 authors = ["Simone Silvestri"]
-version = "0.1.1"
+version = "0.1.2"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"
+CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 DocumenterTools = "35a29f4d-8980-5a13-9543-d66fff28ecb8"
 JLD2 = "033835bb-8acc-5ee8-8aae-3f567f8a3819"
@@ -14,15 +15,16 @@ Oceananigans = "9e8cae18-63c1-5223-a75c-80ca9d6e9a09"
 OffsetArrays = "6fe1bfb0-de20-5000-8ca7-80f57d26f881"
 
 [compat]
+Adapt = "^4"
+CUDA = "^5"
 Documenter = "1"
 DocumenterTools = "0.1"
 JLD2 = "0.4"
 KernelAbstractions = "0.9"
+MPI = "0.20"
 Oceananigans = "^0.91.3"
 OffsetArrays = "^1"
 julia = "1"
-MPI = "0.20"
-Adapt = "^4"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/src/distributed_tripolar_grid.jl
+++ b/src/distributed_tripolar_grid.jl
@@ -23,7 +23,6 @@ therefore, only splitting the j-direction is supported for the moment.
 """
 function TripolarGrid(arch::Distributed, FT::DataType = Float64; 
                       halo = (4, 4, 4),
-                      jrange = nothing,
                       kwargs...)
 
     workers = ranks(arch.partition)
@@ -45,11 +44,9 @@ function TripolarGrid(arch::Distributed, FT::DataType = Float64;
     nlocal = concatenate_local_sizes(lsize, arch, 2)
     rank   = arch.local_rank
     
-    if isnothing(jrange)
-        jstart = 1 + sum(nlocal[1:rank])
-        jend   = rank == workers[2] ? Ny : sum(nlocal[1:rank+1])
-        jrange = jstart - Hy : jend + Hy
-    end
+    jstart = 1 + sum(nlocal[1:rank])
+    jend   = rank == workers[2] - 1 ? Ny : sum(nlocal[1:rank+1])
+    jrange = jstart - Hy : jend + Hy
 
     # Partitioning the Coordinates
     λᶠᶠᵃ = partition_tripolar_metric(global_grid, :λᶠᶠᵃ, jrange)

--- a/src/distributed_tripolar_grid.jl
+++ b/src/distributed_tripolar_grid.jl
@@ -21,7 +21,10 @@ Constructs a tripolar grid on a distributed architecture.
 A distributed tripolar grid is supported only on a Y-partitioning configuration, 
 therefore, only splitting the j-direction is supported for the moment.
 """
-function TripolarGrid(arch::Distributed, FT::DataType = Float64; halo = (4, 4, 4), kwargs...)
+function TripolarGrid(arch::Distributed, FT::DataType = Float64; 
+                      halo = (4, 4, 4),
+                      jrange = nothing,
+                      kwargs...)
 
     workers = ranks(arch.partition)
 
@@ -41,9 +44,12 @@ function TripolarGrid(arch::Distributed, FT::DataType = Float64; halo = (4, 4, 4
     # Extracting the local range
     nlocal = concatenate_local_sizes(lsize, arch, 2)
     rank   = arch.local_rank
-    jstart = 1 + sum(nlocal[1:rank])
-    jend   = rank == workers[2] ? Ny : sum(nlocal[1:rank+1])
-    jrange = jstart - Hy : jend + Hy
+    
+    if isnothing(jrange)
+        jstart = 1 + sum(nlocal[1:rank])
+        jend   = rank == workers[2] ? Ny : sum(nlocal[1:rank+1])
+        jrange = jstart - Hy : jend + Hy
+    end
 
     # Partitioning the Coordinates
     λᶠᶠᵃ = partition_tripolar_metric(global_grid, :λᶠᶠᵃ, jrange)

--- a/src/grid_extensions.jl
+++ b/src/grid_extensions.jl
@@ -16,9 +16,13 @@ import Oceananigans.Grids: x_domain, y_domain
 import Oceananigans.Fields: Field
 import Oceananigans.Fields: tupled_fill_halo_regions!
 
+# Horrible, just for this allowscalar! 
+# we should remove this dependency
+using CUDA: @allowscalar
+
 # A tripolar grid is always between 0 and 360 in longitude!
 x_domain(grid::TRG) = 0, 360
-y_domain(grid::TRG) = minimum(grid.φᶠᶠᵃ), 90
+y_domain(grid::TRG) = @allowscalar minimum(grid.φᶠᶠᵃ), 90
 
 # a `TripolarGrid` needs a `ZipperBoundaryCondition` for the north boundary
 # The `sign` 1 for regular tracers and -1 for velocities and signed vectors


### PR DESCRIPTION
In the previous version I had removed `@allowscalar` from 
```julia
y_domain(grid::TRG) = @allowscalar minimum(grid.φᶠᶠᵃ), 90
```
because I thought `minimum(::CuArray)` does not incur in `scalarindexing` problems. 
In this way I could remove the dependency of this package on CUDA.
Apparently `minimum(::OffsetArrays)` does indeed incur in `scalarindexing` problems, so this PR reintroduces CUDA in the dependencies just because of this `@allowscalar`.