### PR TITLE
More liberal Oceananigans compat

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -16,7 +16,7 @@ Adapt = "4"
 JLD2 = "0.4"
 KernelAbstractions = "0.9"
 MPI = "0.20"
-Oceananigans = "≥ 0.91.3"
+Oceananigans = "0.91.3 - 1"
 OffsetArrays = "1"
 julia = "1"
 

--- a/Project.toml
+++ b/Project.toml
@@ -16,7 +16,7 @@ Adapt = "4"
 JLD2 = "0.4"
 KernelAbstractions = "0.9"
 MPI = "0.20"
-Oceananigans = "0.91.3"
+Oceananigans = "≥ 0.91.3"
 OffsetArrays = "1"
 julia = "1"
 

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "OrthogonalSphericalShellGrids"
 uuid = "c2be9673-fb75-4747-82dc-aa2bb9f4aed0"
 authors = ["Climate Modeling Alliance and contributors"]
-version = "0.1.3"
+version = "0.1.4"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"


### PR DESCRIPTION
Otherwise we cannot update Oceananigans' minor version, because OrthogonalSphericalShellGrids is a test dep of Oceananigans.