### PR TITLE
Drop JLD2 dependency

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "OrthogonalSphericalShellGrids"
 uuid = "c2be9673-fb75-4747-82dc-aa2bb9f4aed0"
 authors = ["Climate Modeling Alliance and contributors"]
-version = "0.1.4"
+version = "0.1.5"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"
@@ -13,7 +13,6 @@ OffsetArrays = "6fe1bfb0-de20-5000-8ca7-80f57d26f881"
 
 [compat]
 Adapt = "4"
-JLD2 = "0.4"
 KernelAbstractions = "0.9"
 MPI = "0.20"
 Oceananigans = "0.91.3, 0.92"

--- a/src/OrthogonalSphericalShellGrids.jl
+++ b/src/OrthogonalSphericalShellGrids.jl
@@ -15,7 +15,6 @@ using Oceananigans.Operators
 using Oceananigans.Utils: get_cartesian_nodes_and_vertices
 
 using Adapt 
-using JLD2
 using KernelAbstractions: @kernel, @index
 using KernelAbstractions.Extras.LoopInfo: @unroll
 using OffsetArrays


### PR DESCRIPTION
It seems this was a mistake. It’s causing problems.