### PR TITLE
Use `Distances.haversine`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -5,6 +5,7 @@ version = "0.1.7"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"
+Distances = "b4f34e82-e78d-54a5-968a-f98e89d6e8f7"
 KernelAbstractions = "63c18a36-062a-441e-b654-da1e3ab1ce7c"
 MPI = "da04e1cc-30fd-572f-bb4f-1f8673147195"
 Oceananigans = "9e8cae18-63c1-5223-a75c-80ca9d6e9a09"
@@ -13,6 +14,7 @@ Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 
 [compat]
 Adapt = "4"
+Distances = "0.10"
 KernelAbstractions = "0.9"
 MPI = "0.20"
 Oceananigans = "0.91.3, 0.92 - 0.99"

--- a/src/OrthogonalSphericalShellGrids.jl
+++ b/src/OrthogonalSphericalShellGrids.jl
@@ -15,7 +15,8 @@ using Oceananigans.Grids: R_Earth,
 using Oceananigans.Operators
 using Oceananigans.Utils: get_cartesian_nodes_and_vertices
 
-using Adapt 
+using Adapt
+using Distances: haversine
 using KernelAbstractions: @kernel, @index
 using KernelAbstractions.Extras.LoopInfo: @unroll
 using OffsetArrays

--- a/src/tripolar_grid_utils.jl
+++ b/src/tripolar_grid_utils.jl
@@ -1,17 +1,5 @@
-# Is this the same as in Oceananigans? 
-# TODO: check it out
-function haversine(a, b, radius)
-    λ₁, φ₁ = a
-    λ₂, φ₂ = b
-
-    x₁, y₁, z₁ = lat_lon_to_cartesian(φ₁, λ₁, radius)
-    x₂, y₂, z₂ = lat_lon_to_cartesian(φ₂, λ₂, radius)
-
-    return radius * acos(max(-1.0, min((x₁ * x₂ + y₁ * y₂ + z₁ * z₂) / radius^2, 1.0)))
-end
-
 # Calculate the metric terms from the coordinates of the grid
-# Note: There is probably a better way to do this, in Murray (2016) they give analytical 
+# Note: There is probably a better way to do this, in Murray (2016) they give analytical
 # expressions for the metric terms.
 @kernel function _calculate_metrics!(Δxᶠᶜᵃ, Δxᶜᶜᵃ, Δxᶜᶠᵃ, Δxᶠᶠᵃ,
                                      Δyᶠᶜᵃ, Δyᶜᶜᵃ, Δyᶜᶠᵃ, Δyᶠᶠᵃ,
@@ -24,21 +12,21 @@ end
     @inbounds begin
         Δxᶜᶜᵃ[i, j] = haversine((λᶠᶜᵃ[i+1, j], φᶠᶜᵃ[i+1, j]), (λᶠᶜᵃ[i, j],   φᶠᶜᵃ[i, j]),   radius)
         Δxᶠᶜᵃ[i, j] = haversine((λᶜᶜᵃ[i, j],   φᶜᶜᵃ[i, j]),   (λᶜᶜᵃ[i-1, j], φᶜᶜᵃ[i-1, j]), radius)
-        Δxᶜᶠᵃ[i, j] = haversine((λᶠᶠᵃ[i+1, j], φᶠᶠᵃ[i+1, j]), (λᶠᶠᵃ[i, j],   φᶠᶠᵃ[i, j]),   radius) 
+        Δxᶜᶠᵃ[i, j] = haversine((λᶠᶠᵃ[i+1, j], φᶠᶠᵃ[i+1, j]), (λᶠᶠᵃ[i, j],   φᶠᶠᵃ[i, j]),   radius)
         Δxᶠᶠᵃ[i, j] = haversine((λᶜᶠᵃ[i, j],   φᶜᶠᵃ[i, j]),   (λᶜᶠᵃ[i-1, j], φᶜᶠᵃ[i-1, j]), radius)
 
         Δyᶜᶜᵃ[i, j] = haversine((λᶜᶠᵃ[i, j+1], φᶜᶠᵃ[i, j+1]),   (λᶜᶠᵃ[i, j],   φᶜᶠᵃ[i, j]),   radius)
         Δyᶠᶜᵃ[i, j] = haversine((λᶠᶠᵃ[i, j+1], φᶠᶠᵃ[i, j+1]),   (λᶠᶠᵃ[i, j],   φᶠᶠᵃ[i, j]),   radius)
         Δyᶜᶠᵃ[i, j] = haversine((λᶜᶜᵃ[i, j  ],   φᶜᶜᵃ[i, j]),   (λᶜᶜᵃ[i, j-1], φᶜᶜᵃ[i, j-1]), radius)
         Δyᶠᶠᵃ[i, j] = haversine((λᶠᶜᵃ[i, j  ],   φᶠᶜᵃ[i, j]),   (λᶠᶜᵃ[i, j-1], φᶠᶜᵃ[i, j-1]), radius)
-    
+
         a = lat_lon_to_cartesian(φᶠᶠᵃ[ i ,  j ], λᶠᶠᵃ[ i ,  j ], 1)
         b = lat_lon_to_cartesian(φᶠᶠᵃ[i+1,  j ], λᶠᶠᵃ[i+1,  j ], 1)
         c = lat_lon_to_cartesian(φᶠᶠᵃ[i+1, j+1], λᶠᶠᵃ[i+1, j+1], 1)
         d = lat_lon_to_cartesian(φᶠᶠᵃ[ i , j+1], λᶠᶠᵃ[ i , j+1], 1)
 
         Azᶜᶜᵃ[i, j] = spherical_area_quadrilateral(a, b, c, d) * radius^2
-        
+
         # To be able to conserve kinetic energy specifically the momentum equation, 
         # it is better to define the face areas as products of 
         # the edge lengths rather than using the spherical area of the face (cit JMC).
@@ -52,6 +40,6 @@ end
         c = lat_lon_to_cartesian(φᶜᶜᵃ[ i ,  j ], λᶜᶜᵃ[ i ,  j ], 1)
         d = lat_lon_to_cartesian(φᶜᶜᵃ[i-1,  j ], λᶜᶜᵃ[i-1,  j ], 1)
 
-        Azᶠᶠᵃ[i, j] = spherical_area_quadrilateral(a, b, c, d) * radius^2 
+        Azᶠᶠᵃ[i, j] = spherical_area_quadrilateral(a, b, c, d) * radius^2
     end
 end


### PR DESCRIPTION
This PR uses `Distances.haversine` in favor of defining a custom made method. The two give indistinguishable results:

```Julia
using Oceananigans.Grids: lat_lon_to_cartesian
using Distances

function haversine_custom(a, b, radius)
    λ₁, φ₁ = a
    λ₂, φ₂ = b

    x₁, y₁, z₁ = lat_lon_to_cartesian(φ₁, λ₁, radius)
    x₂, y₂, z₂ = lat_lon_to_cartesian(φ₂, λ₂, radius)

    return radius * acos(max(-1.0, min((x₁ * x₂ + y₁ * y₂ + z₁ * z₂) / radius^2, 1.0)))
end

using Test

for i in 1:100
    (λ1, φ1) = rand()*360, (2rand()-1)*90
    (λ2, φ2) = rand()*360, (2rand()-1)*90

    radius = rand() * 6300e3

    @test haversine_custom((λ1, φ1), (λ2, φ2), radius) ≈ Distances.haversine((λ1, φ1), (λ2, φ2), radius)
end
```